### PR TITLE
updates _CryptoIonHasher such that the single-use Hash object is replaced after digest() is called

### DIFF
--- a/src/internal/IonHashImpl.ts
+++ b/src/internal/IonHashImpl.ts
@@ -6,13 +6,19 @@ import {createHash, Hash} from 'crypto';
 import {IonHasher, IonHasherProvider, IonHashReader, IonHashWriter} from "../IonHash";
 
 export class _CryptoIonHasher implements IonHasher {
-    private readonly _hash: Hash;
+    private _hash: Hash;
 
-    constructor(algorithm: string) {
+    constructor(private readonly algorithm: string) {
         this._hash = createHash(algorithm);
     }
-    update(bytes: Uint8Array): void { this._hash.update(bytes) }
-    digest(): Uint8Array { return this._hash.digest() }
+    update(bytes: Uint8Array): void {
+        this._hash.update(bytes);
+    }
+    digest(): Uint8Array {
+        let digest = this._hash.digest();
+        this._hash = createHash(this.algorithm);
+        return digest;
+    }
 }
 
 
@@ -478,8 +484,8 @@ class _Serializer {
 }
 
 class _StructSerializer extends _Serializer {
-    _scalarSerializer: _Serializer;
-    _fieldHashes: Uint8Array[] = [];
+    private readonly _scalarSerializer: _Serializer;
+    private readonly _fieldHashes: Uint8Array[] = [];
 
     constructor(hashFunction: IonHasher,
                 depth: number,

--- a/tests/CryptoIonHasherProviderTest.ts
+++ b/tests/CryptoIonHasherProviderTest.ts
@@ -7,17 +7,13 @@ import {cryptoIonHasherProvider, makeHashReader, makeHashWriter} from '../src/Io
 import {toHexString} from './testutil';
 
 registerSuite('CryptoIonHasherProviderTests', {
-    cryptoMD5reader: () => {
-        let str = '[1, 2, {a: 3, b: (4 {c: 5} 6) }, 7]';
-        let expectedDigest = 'dd 20 84 69 9a 2e 85 fe ef 64 c8 79 57 b6 9f cd';
+    cryptoMD5reader: () => testReader(
+        '[1, 2, {a: 3, b: (4 {c: 5} 6) }, 7]',
+        'dd 20 84 69 9a 2e 85 fe ef 64 c8 79 57 b6 9f cd'),
 
-        let hashReader = makeHashReader(makeReader(str), cryptoIonHasherProvider('md5'));
-        hashReader.next();
-        hashReader.next();
-        let actualDigest = hashReader.digest();
-
-        assert.equal(toHexString(actualDigest), expectedDigest);
-    },
+    cryptoMD5readerStructWithMultipleScalarFields: () => testReader(
+        '{a: 1, b: 2}',
+        '52 30 a3 c4 0d a0 d5 95 28 bb e5 01 90 f4 0c 23'),
 
     cryptoMD5writer: () => {
         let expectedIon = '[1,2,{a:3,b:(4 {c:5} 6)},7]';
@@ -57,4 +53,13 @@ registerSuite('CryptoIonHasherProviderTests', {
         });
     },
 });
+
+function testReader(input: string, expectedDigest: string) {
+    let hashReader = makeHashReader(makeReader(input), cryptoIonHasherProvider('md5'));
+    hashReader.next();
+    hashReader.next();
+    let actualDigest = hashReader.digest();
+
+    assert.equal(toHexString(actualDigest), expectedDigest);
+}
 


### PR DESCRIPTION
Resolves #19 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
