### PR TITLE
Avoids a 'src' path in the distribution and bumps ion-js dependency from 3.0.0 to 3.1.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,16 +21,14 @@ module.exports = function(grunt) {
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
 
-    clean: ['dist', 'docs'],
+    clean: ['build', 'dist', 'docs'],
 
     ts: {
-      tsconfig: 'tsconfig.json',
       'commonjs-es5': {
-        outDir: 'dist/commonjs/es5',
-        options: {
-          target: 'es5',
-          module: 'commonjs',
-        },
+        tsconfig: 'tsconfig.commonjs.json',
+      },
+      'tests': {
+        tsconfig: 'tsconfig.tests.json',
       },
     },
 
@@ -39,7 +37,7 @@ module.exports = function(grunt) {
         options: {
           reporters: ['runner'],
           suites: [
-            'dist/commonjs/es5/**/*.js',
+            'build/tests/*.js',
           ],
         },
       },
@@ -63,7 +61,7 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask('build',   ['clean', 'ts:commonjs-es5']);
-  grunt.registerTask('test',    ['build', 'intern:es5']);
+  grunt.registerTask('test',    ['build', 'ts:tests', 'intern:es5']);
   grunt.registerTask('doc',     ['typedoc']);
 
   grunt.registerTask('default', ['test']);

--- a/package.json
+++ b/package.json
@@ -28,13 +28,11 @@
     "grunt-ts": "^6.0.0-beta.19",
     "grunt-typedoc": "^0.2.4",
     "intern": "^4.4.3",
-    "jsbi": "^3.1.1",
     "typedoc": "^0.14.2",
     "typescript": "^3.5.3"
   },
   "dependencies": {
     "crypto": "^1.0.1",
-    "ion-js": "^3.1.1"
+    "ion-js": "^3.1.2"
   }
 }
-

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "crypto": "^1.0.1",
-    "ion-js": "^3.0.0"
+    "ion-js": "^3.1.1"
   }
 }
 

--- a/tsconfig.commonjs.json
+++ b/tsconfig.commonjs.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/commonjs/es5"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,13 @@
 {
   "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
     "declaration": true,
     "noImplicitAny": true,
-    "rootDirs": ["src", "tests"],
     "sourceMap": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "types": ["intern"],
     "verbose": true
-  },
-  "include": [
-    "src/**/*.ts",
-    "tests/**/*.ts"
-  ]
+  }
 }
 

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "outDir": "build",
+    "types": ["intern"]
+  },
+  "include": [
+    "tests/**/*.ts"
+  ]
+}
+


### PR DESCRIPTION
Prior to these changes, the distribution folder included paths such as `dist/commonjs/es5/src` and `dist/commonjs/es5/tests`.  The tests don't belong in the distribution, and the `src` path is unnecessary.

This PR addresses those aspects of the distribution and fixes the build by depending on the newly-available ion-js 3.1.1 release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
