### PR TITLE
Bumps version to 1.0.1, changes npm package name to 'ion-hash'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ion-hash-js",
-  "version": "1.0.0",
+  "name": "ion-hash",
+  "version": "1.0.1",
   "description": "JavaScript implementation of Amazon Ion Hash",
   "main": "dist/commonjs/es5/IonHash.js",
   "types": "dist/commonjs/es5/IonHash.d.ts",


### PR DESCRIPTION
We currently don't have permission to publish a package named "ion-hash-js" to npm, as someone else took an earlier version of this codebase and published it to npm first.

For the time being, we're planning to publish this library as "ion-hash" to avoid delays while sorting out correct ownership of the "ion-hash-js" package name in npm.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
