### PR TITLE
Bumps version to 1.0.2, changes npm package name back to 'ion-hash-js'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "ion-hash",
-  "version": "1.0.1",
+  "name": "ion-hash-js",
+  "version": "1.0.2",
   "description": "JavaScript implementation of Amazon Ion Hash",
   "main": "dist/commonjs/es5/IonHash.js",
   "types": "dist/commonjs/es5/IonHash.d.ts",


### PR DESCRIPTION
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
