### PR TITLE
Removes crypto dependency, in favor of relying on Node's built-in module

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "crypto": "^1.0.1",
     "ion-js": "^3.1.2"
   }
 }


### PR DESCRIPTION
Per [npmjs.com/crypto](https://www.npmjs.com/package/crypto), the crypto package is no longer supported, but has been moved into node itself.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
