### PR TITLE
Adds a function for computing the hash of any value

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
     "grunt-typedoc": "^0.2.4",
     "intern": "^4.4.3",
     "ion-js": "^3.1.2",
+    "jsbi": "^3.1.1",
     "typedoc": "^0.14.2",
     "typedoc-plugin-no-inherit": "^1.1.10",
     "typescript": "^3.5.3"
   },
   "peerDependencies": {
-    "ion-js": "^3.1.2"
+    "ion-js": "^3.1.2",
+    "jsbi": "^3.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-typedoc": "^0.2.4",
     "intern": "^4.4.3",
     "ion-js": "^3.1.2",
-    "jsbi": "^3.1.1",
+    "jsbi": "3.1.1",
     "typedoc": "^0.14.2",
     "typedoc-plugin-no-inherit": "^1.1.10",
     "typescript": "^3.5.3"

--- a/src/IonHash.ts
+++ b/src/IonHash.ts
@@ -122,8 +122,9 @@ export function cryptoHasherProvider(algorithm: string): HasherProvider {
 }
 
 /**
- * Computes the Ion hash for the given a value and the name of an algorithm known to
- * node's [crypto](https://node.readthedocs.io/en/latest/api/crypto/) module.
+ * Computes the Ion hash of a value using the specified hash algorithm.
+ * The algorithm must be known to node's
+ * [crypto](https://node.readthedocs.io/en/latest/api/crypto/) module.
  *
  * @param value the native JavaScript value or instance of ion-js's dom.Value to be hashed
  * @param algorithm specifies the algorithm to use when invoking `crypto.createHash()`

--- a/src/IonHash.ts
+++ b/src/IonHash.ts
@@ -13,7 +13,7 @@
  * permissions and limitations under the License.
  */
 
-import {Reader, Writer} from 'ion-js';
+import {dom, makeBinaryWriter, Reader, Writer} from 'ion-js';
 
 import {_HashReaderImpl, _HashWriterImpl, _CryptoHasher} from './internal/IonHashImpl';
 
@@ -119,5 +119,26 @@ export interface Hasher {
  */
 export function cryptoHasherProvider(algorithm: string): HasherProvider {
     return (): Hasher => { return new _CryptoHasher(algorithm) };
+}
+
+/**
+ * Computes the Ion hash for the given a value and the name of an algorithm known to
+ * node's [crypto](https://node.readthedocs.io/en/latest/api/crypto/) module.
+ *
+ * @param value the native JavaScript value or instance of ion-js's dom.Value to be hashed
+ * @param algorithm specifies the algorithm to use when invoking `crypto.createHash()`
+ *                  (e.g., 'sha1', 'md5', 'sha256', 'sha512')
+ * @return bytes representing the Ion hash of the value
+ * @throws if the specified algorithm isn't supported
+ */
+export function digest(value: any, algorithm: string): Uint8Array {
+    let writer = makeBinaryWriter();
+    let hashProvider = cryptoHasherProvider(algorithm);
+    let hashWriter = makeHashWriter(writer, hashProvider);
+    dom.Value.from(value).writeTo(hashWriter);
+    hashWriter.close();
+    writer.close();
+
+    return hashWriter.digest();
 }
 

--- a/tests/BigListOfNaughtyStringsTests.ts
+++ b/tests/BigListOfNaughtyStringsTests.ts
@@ -13,13 +13,13 @@
  * permissions and limitations under the License.
  */
 
-import {makeBinaryWriter, makeReader} from 'ion-js';
+import {load, makeBinaryWriter, makeReader} from 'ion-js';
 
 const {registerSuite} = intern.getPlugin('interface.object');
 const {assert} = intern.getPlugin('chai');
 import {readFileSync} from 'fs';
 
-import {HashReader, HashWriter, makeHashReader, makeHashWriter} from '../src/IonHash';
+import {digest, HashReader, HashWriter, makeHashReader, makeHashWriter} from '../src/IonHash';
 import {testHasherProvider, toHexString, writeln} from './testutil';
 
 class TestValue {
@@ -179,8 +179,9 @@ function runTest(tv: TestValue, testString: string) {
     }
 
     if (tv.validIon == null || tv.validIon) {
-        assert.equal(toHexString(hashWriter!.digest()),
-            toHexString(hashReader!.digest()));
+        let writerDigest = toHexString(hashWriter!.digest());
+        assert.deepEqual(writerDigest, toHexString(hashReader!.digest()));
+        assert.deepEqual(writerDigest, toHexString(digest(load(testString), 'md5')));
     }
 }
 

--- a/tests/DigestTest.ts
+++ b/tests/DigestTest.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/tests/DigestTest.ts
+++ b/tests/DigestTest.ts
@@ -1,12 +1,12 @@
 /*
  * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *  
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing

--- a/tests/DigestTest.ts
+++ b/tests/DigestTest.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *  
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *  
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *  
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+import {Decimal, load, Timestamp} from 'ion-js';
+
+const {registerSuite} = intern.getPlugin('interface.object');
+const {assert} = intern.getPlugin('chai');
+
+import {digest} from '../src/IonHash';
+
+registerSuite('digest', {
+    true: () => assert.deepEqual(
+        digest(true, 'md5'),
+        Uint8Array.from([0xa7, 0x51, 0x0a, 0x8e, 0x9a, 0x56, 0xd0, 0x23,
+                         0x29, 0x27, 0x2e, 0xb4, 0x96, 0x66, 0xde, 0x12])
+    ),
+    allTypes: () => assert.deepEqual(
+        digest([
+            null,
+            true,
+            1,
+            -1,
+            load('1e0'),
+            Decimal.parse('1d0'),
+            Timestamp.parse('2017-01-01T00:00:00-00:00'),
+            load('hello'),
+            "hello",
+            load('{{"hello"}}'),
+            load('{{aGVsbG8=}}'),
+            [1, 2, 3],
+            load('(1 2 3)'),
+            { c:3, a:1, b:2 },
+            load('hello::null')],
+            'md5'),
+        Uint8Array.from([0xb0, 0xd9, 0x03, 0x45, 0xdb, 0x55, 0x79, 0xf1,
+                         0xd8, 0x2f, 0x12, 0xae, 0x92, 0xc3, 0x23, 0xb5])
+    ),
+    unknownAlgorithm: () => assert.throws(() => digest(5, 'unknownAlgorithm')),
+});
+

--- a/tests/IonHashTests.ts
+++ b/tests/IonHashTests.ts
@@ -31,7 +31,9 @@ interface Digester {
     (ionData: string | Uint8Array, algorithm: string, hasherLog: string[]): void;
 }
 
-let binaryReaderDigester: Digester = (ionData: string | Uint8Array, algorithm: string, hasherLog: string[]): void => {
+let binaryReaderDigester: Digester = (ionData: string | Uint8Array,
+                                      algorithm: string,
+                                      hasherLog: string[]): void => {
     let reader = makeReader(ionData);
     let writer = makeBinaryWriter();
     reader.next();
@@ -41,7 +43,9 @@ let binaryReaderDigester: Digester = (ionData: string | Uint8Array, algorithm: s
     readerDigester(makeReader(ionBinary), algorithm, hasherLog);
 };
 
-let textReaderDigester: Digester = (ionData: string | Uint8Array, algorithm: string, hasherLog: string[]): void => {
+let textReaderDigester: Digester = (ionData: string | Uint8Array,
+                                    algorithm: string,
+                                    hasherLog: string[]): void => {
     readerDigester(makeReader(ionData), algorithm, hasherLog);
 };
 
@@ -60,7 +64,9 @@ function readerDigester(reader: Reader, algorithm: string, hasherLog: string[]):
     hashReader.digest();
 }
 
-let readerSkipDigester: Digester = (ionData: string | Uint8Array, algorithm: string, hasherLog: string[]): void => {
+let readerSkipDigester: Digester = (ionData: string | Uint8Array,
+                                    algorithm: string,
+                                    hasherLog: string[]): void => {
     let hashReader = makeHashReader(
         makeReader(ionData),
         testHasherProvider(algorithm, hasherLog));
@@ -69,15 +75,22 @@ let readerSkipDigester: Digester = (ionData: string | Uint8Array, algorithm: str
     hashReader.digest();
 };
 
-let binaryWriterDigester: Digester = (ionData: string | Uint8Array, algorithm: string, hasherLog: string[]): void => {
+let binaryWriterDigester: Digester = (ionData: string | Uint8Array,
+                                      algorithm: string,
+                                      hasherLog: string[]): void => {
     writerDigester(makeBinaryWriter(), ionData, algorithm, hasherLog);
 };
 
-let textWriterDigester: Digester = (ionData: string | Uint8Array, algorithm: string, hasherLog: string[]): void => {
+let textWriterDigester: Digester = (ionData: string | Uint8Array,
+                                    algorithm: string,
+                                    hasherLog: string[]): void => {
     writerDigester(makeTextWriter(), ionData, algorithm, hasherLog);
 };
 
-function writerDigester(writer: Writer, ionData: string | Uint8Array, algorithm: string, hasherLog: string[]): void {
+function writerDigester(writer: Writer,
+                        ionData: string | Uint8Array,
+                        algorithm: string,
+                        hasherLog: string[]): void {
     let reader = makeReader(ionData);
     reader.next();
     let hashWriter = makeHashWriter(writer, testHasherProvider(algorithm, hasherLog));
@@ -85,7 +98,9 @@ function writerDigester(writer: Writer, ionData: string | Uint8Array, algorithm:
     hashWriter.digest();
 }
 
-let digestFunctionDigester: Digester = (ionData: string | Uint8Array, algorithm: string, hasherLog: string[]): void => {
+let digestFunctionDigester: Digester = (ionData: string | Uint8Array,
+                                        algorithm: string,
+                                        hasherLog: string[]): void => {
     let value = load(ionData);
     let digest = ionhash.digest(value, algorithm);
     hasherLog.push('final_digest::(' + toHexString(digest) + ')');

--- a/tests/IonHashTests.ts
+++ b/tests/IonHashTests.ts
@@ -116,7 +116,7 @@ function test(ionData: string | Uint8Array,
 
     } else if (actualHasherLog.length == 1
             && actualHasherLog[0].startsWith('final_digest::')) {
-        // added so the digestFunctionDigester can assert against just the final
+        // added so the digestFunction digester can assert against just the final
         // expected md5 hash (as it can't provide intermediate md5 hashes):
         assert.deepEqual(actualHasherLog[0], 'final_' + expectedHasherLog.pop());
 

--- a/tests/IonHashTests.ts
+++ b/tests/IonHashTests.ts
@@ -19,8 +19,9 @@ const {registerSuite} = intern.getPlugin('interface.object');
 const {assert} = intern.getPlugin('chai');
 import {readFileSync} from 'fs';
 
-import {makeBinaryWriter, makeReader, makeTextWriter, Reader, Writer} from 'ion-js';
+import {load, makeBinaryWriter, makeReader, makeTextWriter, Reader, Writer} from 'ion-js';
 import {makeHashReader, makeHashWriter} from '../src/IonHash';
+import * as ionhash from '../src/IonHash';
 import {sexpToBytes, testHasherProvider, toHexString, readerToString, writeln} from './testutil';
 
 // builds a test suite based on the contents of ion_hash_tests.ion
@@ -84,12 +85,19 @@ function writerDigester(writer: Writer, ionData: string | Uint8Array, algorithm:
     hashWriter.digest();
 }
 
+let digestFunctionDigester: Digester = (ionData: string | Uint8Array, algorithm: string, hasherLog: string[]): void => {
+    let value = load(ionData);
+    let digest = ionhash.digest(value, algorithm);
+    hasherLog.push('final_digest::(' + toHexString(digest) + ')');
+};
+
 let digesters: { [digesterName: string]: Digester } = {
     BinaryReader: binaryReaderDigester,
     BinaryWriter: binaryWriterDigester,
     ReaderSkip: readerSkipDigester,
     TextReader: textReaderDigester,
     TextWriter: textWriterDigester,
+    digestFunction: digestFunctionDigester,
 };
 
 function test(ionData: string | Uint8Array,
@@ -103,8 +111,15 @@ function test(ionData: string | Uint8Array,
     digester(ionData, algorithm, actualHasherLog);
 
     if (expectedHasherLog.length == 1
-        && expectedHasherLog[0].startsWith('final_digest::')) {
+            && expectedHasherLog[0].startsWith('final_digest::')) {
         assert.deepEqual('final_' + actualHasherLog.pop(), expectedHasherLog[0]);
+
+    } else if (actualHasherLog.length == 1
+            && actualHasherLog[0].startsWith('final_digest::')) {
+        // added so the digestFunctionDigester can assert against just the final
+        // expected md5 hash (as it can't provide intermediate md5 hashes):
+        assert.deepEqual(actualHasherLog[0], 'final_' + expectedHasherLog.pop());
+
     } else {
         if (algorithm == 'md5') {
             expectedHasherLog = expectedHasherLog.filter(
@@ -162,8 +177,10 @@ for (let type; type = reader.next(); ) {
         }
 
         for (const digester in digesters) {
-            suites[digester][theTestName] = () => {
-                test(ionData, algorithm, expects[algorithm], digesters[digester]);
+            if (!(digester == 'digestFunction' && algorithm == 'identity')) {
+                suites[digester][theTestName] = () => {
+                    test(ionData, algorithm, expects[algorithm], digesters[digester]);
+                }
             }
         }
     }


### PR DESCRIPTION
Resolves #43 

* adds and exports `digest(value: any, algorithm: string): Uint8Array` function
* adds unit tests
* incorporates `digest()` into IonHashTests and BigListOfNaughtyStrings test suites

Build currently fails becuase ion-hash-js depends on a version of ion-js that doesn't export `dom`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
