### PR TITLE
Upgrades typedoc devDependency to 0.17.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "intern": "^4.4.3",
     "ion-js": "^4.0.0",
     "jsbi": "3.1.1",
-    "typedoc": "^0.14.2",
+    "typedoc": "^0.17.3",
     "typedoc-plugin-no-inherit": "^1.1.10",
     "typescript": "^3.5.3"
   },


### PR DESCRIPTION
This addresses the current build failure:  `Error:  An accessor cannot be declared in an ambient context.`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
