### PR TITLE
Adds missing Reader method impls in _HashReaderImpl

### DIFF
--- a/src/internal/IonHashImpl.ts
+++ b/src/internal/IonHashImpl.ts
@@ -70,6 +70,8 @@ export class _HashReaderImpl implements HashReader, _IonValue {
     timestampValue(): Timestamp | null  { return this._reader.timestampValue() }
     type()          : IonType | null    { return this._reader.type() }
     value()         : ReaderScalarValue { return this._reader.value() }
+    position()      : number            { return this._reader.position() }
+    uInt8ArrayValue(): Uint8Array | null { return this._reader.uInt8ArrayValue() }
 
     private _traverse() {
         for (let type; type = this.next(); ) {

--- a/tests/HashReaderTest.ts
+++ b/tests/HashReaderTest.ts
@@ -14,6 +14,7 @@
  */
 
 import JSBI from "jsbi";
+import intern from 'intern';
 
 const {registerSuite} = intern.getPlugin('interface.object');
 const {assert} = intern.getPlugin('chai');
@@ -107,6 +108,16 @@ class ReaderComparer implements Reader {
     stepOut() {
         this.readerA.stepOut();
         this.readerB.stepOut();
+    }
+
+    position(): number {
+        assert.deepEqual(this.readerA.position(), this.readerB.position());
+        return this.readerA.position()
+    }
+
+    uInt8ArrayValue(): Uint8Array | null {
+        assert.deepEqual(this.readerA.uInt8ArrayValue(), this.readerB.uInt8ArrayValue());
+        return this.readerA.uInt8ArrayValue()
     }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es5",
     "module": "commonjs",
     "declaration": true,
+    "esModuleInterop": true,
     "noImplicitAny": true,
     "sourceMap": true,
     "strictNullChecks": true,


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

Adds missing Reader method impls in _HashReaderImpl

There have been two functions added to the `Reader` interface in `ion-js` (https://github.com/amzn/ion-js/pull/672, https://github.com/amzn/ion-js/pull/657), but `ion-hash-js` was never updated. This was causing `npm run release` to fail.

I've added in the missing methods. Also, for some reason unknown to me, `tsc` is now complaining about using `intern` in `HashReaderTests.ts` without properly importing it, so I also had to update that.




*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
